### PR TITLE
docs: add review comments for PRs #8 and #9

### DIFF
--- a/REVIEW_PR8.md
+++ b/REVIEW_PR8.md
@@ -1,0 +1,5 @@
+@cp90-pixel Thanks for the PR! Initial review:
+- `luanti_voyager/challenge_system/leaderboard.py` references `uuid4` but only imports `UUID`, causing a `NameError`. Please add `uuid4` to the imports and rerun `pytest tests/test_challenge_system.py`.
+- The PR introduces roughly 2.4k lines across many new modules. Consider splitting into smaller pieces or adding more documentation to ease review and maintenance.
+
+To work with related PRs, merge this one first (after fixes) before addressing PR #9, which builds on it.

--- a/REVIEW_PR9.md
+++ b/REVIEW_PR9.md
@@ -1,0 +1,6 @@
+@cp90-pixel Thanks for continuing the work with adaptive learning. Initial review:
+- This branch includes the entire community challenge commit from PR #8 (`dd3089e`). Once PR #8 is merged, please rebase so PR #9 only contains the adaptive learning changes.
+- The `uuid4` import issue persists here because it pulls in the same code. Fixing it in PR #8 and rebasing will resolve it.
+- Adding unit tests or examples for `learning.py` would help verify the new behavior.
+
+These changes depend on PR #8, so merge that one first, then rebase and refine this PR.


### PR DESCRIPTION
## Summary
- add `REVIEW_PR8.md` with notes on fixing missing `uuid4` import and suggesting smaller, documented modules
- add `REVIEW_PR9.md` noting duplicated commit from PR #8 and recommending rebase plus extra tests

## Testing
- `pytest -q` *(fails: VoyagerAgent._decide_action takes 1 positional argument but 2 were given; OllamaLLM __init__ unexpected keyword argument 'agent_name')*


------
https://chatgpt.com/codex/tasks/task_e_688fa4e3cc28832e8db1b48d88503b7a